### PR TITLE
Add simple Android reflex game

### DIFF
--- a/ReflexGame/README.md
+++ b/ReflexGame/README.md
@@ -1,0 +1,11 @@
+# ReflexGame
+
+Bu basit Android oyunu, reflekslerinizi test etmek için tasarlandı. Uygulama ekrana rastgele konumlanan bir buton yerleştirir. Butona her dokunduğunuzda skorunuz bir artar ve buton başka bir konuma taşınır.
+
+## Özellikler
+- Kotlin ile yazılmış basit oyun döngüsü
+- Rastgele konumlanan buton
+- Her dokunuşta artan skor
+
+## Çalıştırma
+Android Studio ile projeyi açmak için klasörü `ReflexGame` dizininden içe aktarın. Ardından `app` modülünü çalıştırarak oyunu cihazınızda veya emülatörde deneyebilirsiniz.

--- a/ReflexGame/app/build.gradle
+++ b/ReflexGame/app/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+}
+
+android {
+    compileSdk 33
+
+    defaultConfig {
+        applicationId "com.example.reflexgame"
+        minSdk 21
+        targetSdk 33
+        versionCode 1
+        versionName "1.0"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.8.0"
+    implementation 'androidx.core:core-ktx:1.10.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.9.0'
+}

--- a/ReflexGame/app/proguard-rules.pro
+++ b/ReflexGame/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Proguard rules for ReflexGame

--- a/ReflexGame/app/src/main/AndroidManifest.xml
+++ b/ReflexGame/app/src/main/AndroidManifest.xml
@@ -1,0 +1,19 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.reflexgame">
+
+    <application
+        android:allowBackup="true"
+        android:label="ReflexGame"
+        android:supportsRtl="true"
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:theme="@style/Theme.ReflexGame">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/ReflexGame/app/src/main/java/com/example/reflexgame/MainActivity.kt
+++ b/ReflexGame/app/src/main/java/com/example/reflexgame/MainActivity.kt
@@ -1,0 +1,53 @@
+package com.example.reflexgame
+
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.view.View
+import android.widget.Button
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import kotlin.random.Random
+
+class MainActivity : AppCompatActivity() {
+    private lateinit var scoreText: TextView
+    private lateinit var hitButton: Button
+    private var score = 0
+    private val handler = Handler(Looper.getMainLooper())
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        scoreText = findViewById(R.id.scoreText)
+        hitButton = findViewById(R.id.hitButton)
+
+        hitButton.setOnClickListener {
+            score++
+            scoreText.text = "Score: $score"
+            moveButton()
+        }
+
+        delayButton()
+    }
+
+    private fun delayButton() {
+        hitButton.visibility = View.INVISIBLE
+        handler.postDelayed({
+            hitButton.post {
+                moveButton()
+                hitButton.visibility = View.VISIBLE
+            }
+        }, 1000)
+    }
+
+    private fun moveButton() {
+        val parent = hitButton.parent as View
+        val maxX = parent.width - hitButton.width
+        val maxY = parent.height - hitButton.height
+        if (maxX > 0 && maxY > 0) {
+            hitButton.translationX = Random.nextInt(maxX).toFloat()
+            hitButton.translationY = Random.nextInt(maxY).toFloat()
+        }
+    }
+}

--- a/ReflexGame/app/src/main/res/layout/activity_main.xml
+++ b/ReflexGame/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/scoreText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top|center_horizontal"
+        android:padding="16dp"
+        android:text="Score: 0"
+        android:textSize="24sp" />
+
+    <Button
+        android:id="@+id/hitButton"
+        android:layout_width="100dp"
+        android:layout_height="100dp"
+        android:layout_gravity="center"
+        android:text="Hit!" />
+
+</FrameLayout>

--- a/ReflexGame/app/src/main/res/values-v21/themes.xml
+++ b/ReflexGame/app/src/main/res/values-v21/themes.xml
@@ -1,0 +1,6 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.ReflexGame" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="android:statusBarColor" tools:targetApi="l">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@color/black</item>
+    </style>
+</resources>

--- a/ReflexGame/app/src/main/res/values/colors.xml
+++ b/ReflexGame/app/src/main/res/values/colors.xml
@@ -1,0 +1,8 @@
+<resources>
+    <color name="purple_500">#6200EE</color>
+    <color name="purple_700">#3700B3</color>
+    <color name="teal_200">#03DAC5</color>
+    <color name="teal_700">#018786</color>
+    <color name="black">#000000</color>
+    <color name="white">#FFFFFF</color>
+</resources>

--- a/ReflexGame/app/src/main/res/values/strings.xml
+++ b/ReflexGame/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">ReflexGame</string>
+</resources>

--- a/ReflexGame/app/src/main/res/values/themes.xml
+++ b/ReflexGame/app/src/main/res/values/themes.xml
@@ -1,0 +1,5 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.ReflexGame" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="android:statusBarColor" tools:targetApi="l">@android:color/transparent</item>
+    </style>
+</resources>

--- a/ReflexGame/build.gradle
+++ b/ReflexGame/build.gradle
@@ -1,0 +1,17 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:7.4.0'
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+

--- a/ReflexGame/settings.gradle
+++ b/ReflexGame/settings.gradle
@@ -1,0 +1,2 @@
+include ':app'
+rootProject.name = 'ReflexGame'


### PR DESCRIPTION
## Summary
- add minimal Android Studio project `ReflexGame`
- implement reflex-based scoring logic in `MainActivity`
- include layout and resource files
- write brief instructions for running the game

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b2ed191f08322bef91fc1d5b9a222